### PR TITLE
Make transmit queue limits and timeout configurable

### DIFF
--- a/thespian/system/transport/__init__.py
+++ b/thespian/system/transport/__init__.py
@@ -2,12 +2,11 @@
 
 from datetime import timedelta
 from thespian.system.timing import ExpirationTimer, currentTime
-from thespian.system.utilis import thesplog
+from thespian.system.utilis import thesplog, str_to_timedelta, getenvdef
 import logging
-import os
 
 
-DEFAULT_MAX_TRANSMIT_PERIOD = timedelta(minutes=int(os.environ.get("THESPIAN_TRANSMIT_TIMEOUT_MINUTES", 5)))
+DEFAULT_MAX_TRANSMIT_PERIOD = getenvdef('THESPIAN_TRANSMIT_TIMEOUT_PERIOD', str_to_timedelta, timedelta(minutes=5))
 TRANSMIT_RETRY_PERIOD       = timedelta(seconds=35)
 MAX_TRANSMIT_RETRIES        = 20
 MAX_SHOWLEN                 = 150

--- a/thespian/system/transport/__init__.py
+++ b/thespian/system/transport/__init__.py
@@ -4,9 +4,10 @@ from datetime import timedelta
 from thespian.system.timing import ExpirationTimer, currentTime
 from thespian.system.utilis import thesplog
 import logging
+import os
 
 
-DEFAULT_MAX_TRANSMIT_PERIOD = timedelta(minutes=5)
+DEFAULT_MAX_TRANSMIT_PERIOD = timedelta(minutes=int(os.environ.get("THESPIAN_TRANSMIT_TIMEOUT_MINUTES", 5)))
 TRANSMIT_RETRY_PERIOD       = timedelta(seconds=35)
 MAX_TRANSMIT_RETRIES        = 20
 MAX_SHOWLEN                 = 150

--- a/thespian/system/transport/asyncTransportBase.py
+++ b/thespian/system/transport/asyncTransportBase.py
@@ -2,7 +2,7 @@
 asynchronous (non-blocking) transmit and receive functionality.
 """
 
-
+import os
 from thespian.system.transport import (TransmitOnly, SendStatus,
                                        Thespian__UpdateWork)
 from thespian.system.utilis import thesplog, partition
@@ -35,9 +35,9 @@ else:
 # transmits are immediately failed instead of being queued.
 
 MAX_PENDING_TRANSMITS = 20
-MAX_QUEUED_TRANSMITS = 950
-QUEUE_TRANSMIT_UNBLOCK_THRESHOLD = 780
-DROP_TRANSMITS_LEVEL = MAX_QUEUED_TRANSMITS + 100
+MAX_QUEUED_TRANSMITS = int(os.environ.get("THESPIAN_MAX_QUEUED_TRANSMITS", 950))
+QUEUE_TRANSMIT_UNBLOCK_THRESHOLD = int(os.environ.get("THESPIAN_QUEUED_TRANSMIT_UNBLOCK_THRESHOLD", 780))
+DROP_TRANSMITS_LEVEL = MAX_QUEUED_TRANSMITS + int(os.environ.get("THESPIAN_DROP_TRANSMITS_LEVEL", 100))
 
 
 @contextmanager

--- a/thespian/system/transport/asyncTransportBase.py
+++ b/thespian/system/transport/asyncTransportBase.py
@@ -2,10 +2,10 @@
 asynchronous (non-blocking) transmit and receive functionality.
 """
 
-import os
+
 from thespian.system.transport import (TransmitOnly, SendStatus,
                                        Thespian__UpdateWork)
-from thespian.system.utilis import thesplog, partition
+from thespian.system.utilis import thesplog, partition, getenvdef
 from thespian.system.timing import ExpirationTimer
 import logging
 from thespian.system.addressManager import CannotPickleAddress
@@ -34,10 +34,10 @@ else:
 # queued transmits exceeds the DROP_TRANSMITS_LEVEL then additional
 # transmits are immediately failed instead of being queued.
 
-MAX_PENDING_TRANSMITS = 20
-MAX_QUEUED_TRANSMITS = int(os.environ.get("THESPIAN_MAX_QUEUED_TRANSMITS", 950))
-QUEUE_TRANSMIT_UNBLOCK_THRESHOLD = int(os.environ.get("THESPIAN_QUEUED_TRANSMIT_UNBLOCK_THRESHOLD", 780))
-DROP_TRANSMITS_LEVEL = MAX_QUEUED_TRANSMITS + int(os.environ.get("THESPIAN_DROP_TRANSMITS_LEVEL", 100))
+MAX_PENDING_TRANSMITS = getenvdef('THESPIAN_MAX_PENDING_TRANSMITS', int, 20)
+MAX_QUEUED_TRANSMITS = getenvdef('THESPIAN_MAX_QUEUED_TRANSMITS', int, 950)
+QUEUE_TRANSMIT_UNBLOCK_THRESHOLD = getenvdef('THESPIAN_QUEUED_TRANSMIT_UNBLOCK_THRESHOLD', int, 780)
+DROP_TRANSMITS_LEVEL = getenvdef('THESPIAN_DROP_TRANSMITS_LEVEL', int, MAX_QUEUED_TRANSMITS + 100)
 
 
 @contextmanager


### PR DESCRIPTION
When actors have longer-running work to do while processing a message, messages can get backed up and eventually exceed the limits set by MAX_QUEUED_TRANSMITS, QUEUE_TRANSMIT_UNBLOCK_THRESHOLD, and DROP_TRANSMITS_LEVEL, or exceed the timeout set by DEFAULT_MAX_TRANSMIT_PERIOD.

This update just makes those values configurable by setting environment variables (and defaults to the original values if those variables are not set).

Users can set the following environment variables:

- THESPIAN_MAX_QUEUED_TRANSMITS to modify MAX_QUEUED_TRANSMITS
- THESPIAN_QUEUED_TRANSMIT_UNBLOCK_THRESHOLD to modify QUEUED_TRANSMIT_UNBLOCK_THRESHOLD
- THESPIAN_DROP_TRANSMITS_LEVEL to modify DROP_TRANSMITS_LEVEL
- THESPIAN_TRANSMIT_TIMEOUT_MINUTES (maybe badly named) to modify DEFAULT_MAX_TRANSMIT_PERIOD